### PR TITLE
Check scalar output type to be python float for forecasting metrics t…

### DIFF
--- a/sktime/performance_metrics/forecasting/tests/test_all_metrics_forecasting.py
+++ b/sktime/performance_metrics/forecasting/tests/test_all_metrics_forecasting.py
@@ -88,7 +88,7 @@ class TestAllForecastingPtMetrics(ForecastingMetricPtFixtureGenerator, QuickTest
         )
 
         if isinstance(multioutput, np.ndarray) or multioutput == "uniform_average":
-            assert all(isinstance(x, float) for x in res.values())
+            assert all(type(x) is float for x in res.values())
         elif multioutput == "raw_values":
             assert all(isinstance(x, np.ndarray) for x in res.values())
             assert all(x.ndim == 1 for x in res.values())


### PR DESCRIPTION
### **Fix: Ensure Forecasting Metrics Return Python Float**  

#### **Summary**  
This PR updates the test case in `TestAllForecastingPtMetrics` to strictly check that forecasting metrics return a **Python `float`** instead of allowing NumPy float types (`np.float64`, etc.).  

#### **Changes Made**  
- Updated the assertion in `test_metric_output_direct`:  
  ```python
  if isinstance(multioutput, np.ndarray) or multioutput == "uniform_average":
      assert all(type(x) is float for x in res.values())  # Ensures strict Python float```
